### PR TITLE
Drafting flare-for with static key-value semantics

### DIFF
--- a/flare/html5/core.py
+++ b/flare/html5/core.py
@@ -2973,7 +2973,7 @@ def fromHTML(html: [str, HtmlAst], appendTo: Widget=None, bindTo: Widget=None, d
 		logging.warning("Using fromHTML(vars=...) is deprecated. Please directly provide your variables as kwargs.")
 		kwargs.update(vars)
 
-	def replaceVars(txt):
+	def replaceVars(txt, vars):
 		if not htmlExpressionEvaluator:
 			return txt
 
@@ -2984,18 +2984,18 @@ def fromHTML(html: [str, HtmlAst], appendTo: Widget=None, bindTo: Widget=None, d
 			ret += txt[:match.start()]
 			txt = txt[match.end():]
 
-			val = htmlExpressionEvaluator.execute(match.group(1), kwargs)
+			val = htmlExpressionEvaluator.execute(match.group(1), vars)
 			ret += str(val) if val is not None else ""
 
 		return ret + txt
 
-	def interpret(parent, items):
+	def interpret(parent, items, vars):
 		ifResult = None
 		ret = []
 
 		for item in items:
 			if isinstance(item, str):
-				txt = TextNode(replaceVars(item))
+				txt = TextNode(replaceVars(item, vars))
 
 				if parent:
 					parent.appendChild(txt)
@@ -3018,7 +3018,7 @@ def fromHTML(html: [str, HtmlAst], appendTo: Widget=None, bindTo: Widget=None, d
 				#print(att, val, ifResult)
 
 				haveConditional = True
-				val = replaceVars(val)
+				val = replaceVars(val, vars)
 
 				if att in ("if", "elif"):
 					if att == "elif":
@@ -3027,7 +3027,7 @@ def fromHTML(html: [str, HtmlAst], appendTo: Widget=None, bindTo: Widget=None, d
 							item = None
 							break
 
-					if not htmlExpressionEvaluator.execute(val, kwargs):
+					if not htmlExpressionEvaluator.execute(val, vars):
 						item = None
 						ifResult = False
 					else:
@@ -3058,7 +3058,11 @@ def fromHTML(html: [str, HtmlAst], appendTo: Widget=None, bindTo: Widget=None, d
 				wdg = __tags[tag][0]()
 
 			for att, val in atts.items():
-				val = replaceVars(val)
+				# Ignore any flare-prefixed attributes here
+				if att.startswith("flare-"):
+					continue
+
+				val = replaceVars(val, vars)
 
 				# The [name] attribute binds the current widget to bindTo under the provided name!
 				if att == "[name]":
@@ -3152,7 +3156,29 @@ def fromHTML(html: [str, HtmlAst], appendTo: Widget=None, bindTo: Widget=None, d
 					except Exception as e:
 						logging.exception(e)
 
-			interpret(wdg, children)
+			# Repeat children within this element?
+			if htmlExpressionEvaluator and (val := atts.get("flare-for")):
+				val = htmlExpressionEvaluator.execute(val, vars)
+
+				if val:
+					lvars = vars.copy()
+
+					if isinstance(val, dict):
+						for k, v in val.items():
+							lvars["key"] = k
+							lvars["value"] = v
+							interpret(wdg, children, lvars)
+
+					elif isinstance(val, list):
+						for v in val:
+							lvars["value"] = v
+							interpret(wdg, children, lvars)
+
+					else:
+						lvars["value"] = val
+						interpret(wdg, children, lvars)
+			else:
+				interpret(wdg, children, vars)
 
 			if parent and not wdg.parent():
 				parent.appendChild(wdg)
@@ -3161,7 +3187,7 @@ def fromHTML(html: [str, HtmlAst], appendTo: Widget=None, bindTo: Widget=None, d
 
 		return ret
 
-	return interpret(appendTo, html)
+	return interpret(appendTo, html, kwargs)
 
 
 if __name__ == '__main__':

--- a/flare/safeeval.py
+++ b/flare/safeeval.py
@@ -29,7 +29,7 @@ class SafeEval:
 		self.nodes: Dict[ast.AST, Callable[[ast.AST, Dict[str, Any]], Any]] = {
 			ast.Call: self.callNode,
 			ast.Compare: self.compareNode,
-			ast.Name: lambda node, names: names[node.id],
+			ast.Name: lambda node, names: names.get(node.id),
 			ast.Constant: lambda node, _: node.n,
 			ast.NameConstant: lambda node, _: node.value,
 			ast.Num: lambda node, _: node.n,


### PR DESCRIPTION
This is a draft for the flare-for-Feature.

This already runs well:

```python
from flare import *

html5.Body().appendChild("""
<select flare-for="items">
    <option value="{{key}}">{{value}}</option>
</select>
""", items={"glider": "Segelflugzeug", "motorglider": "Motorsegler", "microlight": "Ultraleicht"}
)

html5.Body().appendChild("""
<select flare-for="items">
    <option value="{{value}}">{{value}}</option>
</select>
""", items=["Segelflugzeug", "Motorsegler", "Ultraleicht"]
)

html5.Body().appendChild("""
<select flare-for="items">
    <option value="{{value}}">{{value}}</option>
</select>
""", items=1337
)
```