### PR TITLE
recordBone formatString fix

### DIFF
--- a/flare/forms/bones/record.py
+++ b/flare/forms/bones/record.py
@@ -46,8 +46,7 @@ class RecordViewWidget( BaseViewWidget ):
 				self.bone.boneStructure[ "format" ],
 				value,
 				self.bone.boneStructure[ "using" ],
-				language = self.language,
-				prefix = ['dest'] #use dest prefix! < rel and record use the same format dest.XXX
+				language = self.language
 			)
 
 		else:


### PR DESCRIPTION
format-strings in recordBones don't use any prefixes in front of their fields.