### PR TITLE
don't allow shortcuts to close a non closeable Alert Popup

### DIFF
--- a/flare/popup.py
+++ b/flare/popup.py
@@ -176,7 +176,7 @@ class Alert(Popup):
 			self, msg, title=None, className=None, okCallback=None, okLabel=None, icon="icon-info", closeable=True,
 			*args, **kwargs
 	):
-		super().__init__(title, className=None, icon=icon, closeable=closeable, *args, **kwargs)
+		super().__init__(title, className=None, icon=icon, closeable=closeable, enableShortcuts=closeable, *args, **kwargs)
 		self.addClass("popup--alert")
 
 		if className:


### PR DESCRIPTION
When an Alert popup is set to closeable=False there also should be no shortcuts like ESC or anything else allowing to close that widget.