### PR TITLE
Update Flare to work with Pyodide 0.18 and Python 3.9.5

### DIFF
--- a/assets/js/flare.js
+++ b/assets/js/flare.js
@@ -4,7 +4,7 @@ emscripten virtual file system so that they can be called from Pyodide.
 
 Please see docs/setup.md in the section "HTML skeleton" for further information on how to use this script.
 */
-const SITE_PACKAGES = "/lib/python3.8/site-packages";
+const SITE_PACKAGES = "/lib/python3.9/site-packages";
 
 class flare {
 	constructor(config) {
@@ -28,7 +28,7 @@ class flare {
 		let pyodide_config = {"indexURL": indexURL};
 
 		// Await loadPyodide, then run flare config
-		await loadPyodide(pyodide_config);
+		globalThis.pyodide = await loadPyodide(pyodide_config);
 
 		let kickoff = (config.kickoff || "");
 

--- a/assets/js/flare.js
+++ b/assets/js/flare.js
@@ -25,7 +25,10 @@ class flare {
 	}
 
 	async initPyodide(config, indexURL) {
-		let pyodide_config = {"indexURL": indexURL};
+		let pyodide_config = {
+		    "indexURL": indexURL,
+		    "fullStdLib": false
+		};
 
 		// Await loadPyodide, then run flare config
 		globalThis.pyodide = await loadPyodide(pyodide_config);


### PR DESCRIPTION
This little PR enables Flare applications to use Pyodide 0.18 and Pyodide 0.18-nano as its runtime.