### PR TITLE
Improvements for get-pyodide.py and Pyodide 0.18.0

### DIFF
--- a/hello.html
+++ b/hello.html
@@ -10,11 +10,8 @@
 				"load",
 				() => {
 					new flare({
-						// Prelude to be executed before fetching local modules
-						// language=Python
-						//prelude: `
-//import setuptools, micropip
-//`,
+                        // Packages to preload. This can also be specified in the kickoff-code as import.
+                        //packages: ["python-dateutil"],
 
 						// Fetch location for locally available Python modules
 						fetch: {

--- a/tools/get-pyodide.py
+++ b/tools/get-pyodide.py
@@ -1,22 +1,21 @@
 #!/usr/bin/env python3
 import os, sys, json, requests
 
-VERSION = "0.18.0"
+VERSION = "v0.18.0"
 CDN = "https://cdn.jsdelivr.net/pyodide"
-URL = "{CDN}/v{VERSION}/full/{file}"
+URL = "{CDN}/{VERSION}/full/{file}"
 DIR = "pyodide"
 FILES = [
     "pyodide.asm.data",
     "pyodide.asm.data.js",
     "pyodide.asm.js",
     "pyodide.asm.wasm",
-    "pyodide.js",
+    "pyodide.js"
 ]
 
 # Allow to install additional Pyodide pre-built packages by command-line arguments
-PACKAGES = ["distlib", "micropip", "packaging", "pyparsing", "setuptools"] + sys.argv[
-    1:
-]
+PACKAGES = ["distlib", "distutils", "micropip", "packaging", "pyparsing", "setuptools"] + sys.argv[1:]
+
 for package in PACKAGES:
     FILES.extend(
         [

--- a/tools/get-pyodide.py
+++ b/tools/get-pyodide.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 import os, sys, json, requests
 
-VERSION = "0.17.0"
+VERSION = "0.18.0"
 CDN = "https://cdn.jsdelivr.net/pyodide"
 URL = "{CDN}/v{VERSION}/full/{file}"
 DIR = "pyodide"
@@ -74,10 +74,9 @@ packages = requests.get(
     URL.format(file="packages.json", CDN=CDN, VERSION=VERSION)
 ).json()
 
-for part in ["dependencies", "import_name_to_package_name", "versions"]:
-    for k in list(packages[part].keys()):
-        if k not in PACKAGES:
-            del packages[part][k]
+for k in list(packages["packages"].keys()):
+    if k not in PACKAGES:
+        del packages["packages"][k]
 
 with open(file, "w") as f:
     f.write(json.dumps(packages))

--- a/tools/get-pyodide.py
+++ b/tools/get-pyodide.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python3
 import os, sys, json, requests
 
-VERSION = "v0.18.0"
+VERSION = "dev"
+VERSION = "v0.18.0"  # comment this line out to obtain latest dev version
 CDN = "https://cdn.jsdelivr.net/pyodide"
 URL = "{CDN}/{VERSION}/full/{file}"
 DIR = "pyodide"
@@ -31,7 +32,7 @@ if not os.path.isdir(DIR):
     os.mkdir(DIR)
     print("Done")
 
-print(f"Installing Pyodide v{VERSION}:")
+print(f"Installing Pyodide {VERSION}:")
 
 for file in FILES:
     url = URL.format(file=file, CDN=CDN, VERSION=VERSION)
@@ -47,7 +48,7 @@ for file in FILES:
 
     print("Done")
 
-print(f"Done installing Pyodide v{VERSION}")
+print(f"Done installing Pyodide {VERSION}")
 
 # Patch pyodide.js to only use "/pyodide/"
 file = os.path.join(DIR, "pyodide.js")

--- a/tools/get-pyodide.py
+++ b/tools/get-pyodide.py
@@ -1,23 +1,31 @@
 #!/usr/bin/env python3
-import os, sys, json, requests
+import os, sys, json, requests, argparse, pathlib
 
-VERSION = "dev"
-VERSION = "v0.18.0"  # comment this line out to obtain latest dev version
+# Defaults
+VERSION = "v0.18.0"
 CDN = "https://cdn.jsdelivr.net/pyodide"
 URL = "{CDN}/{VERSION}/full/{file}"
-DIR = "pyodide"
 FILES = [
     "pyodide.asm.data",
-    "pyodide.asm.data.js",
     "pyodide.asm.js",
     "pyodide.asm.wasm",
     "pyodide.js"
 ]
+PACKAGES = ["distlib", "distutils", "micropip", "packaging", "pyparsing", "setuptools"]
+
+# Parse command line arguments
+ap = argparse.ArgumentParser(description="Service program to obtain self-hosted, stripped copy of Pyodide from CDN")
+ap.add_argument(
+    "-v", "--pyodide", dest="version", default=VERSION, choices=[VERSION, "dev"], help="Pyodide version to download"
+)
+ap.add_argument("-p", "--packages", nargs="*", help="Further packages to download")
+ap.add_argument("-t", "--target", type=pathlib.Path, default="pyodide", help="Target folder")
+args = ap.parse_args()
 
 # Allow to install additional Pyodide pre-built packages by command-line arguments
-PACKAGES = ["distlib", "distutils", "micropip", "packaging", "pyparsing", "setuptools"] + sys.argv[1:]
+packages = PACKAGES + (args.packages or [])
 
-for package in PACKAGES:
+for package in packages:
     FILES.extend(
         [
             f"{package}.data",
@@ -25,33 +33,35 @@ for package in PACKAGES:
         ]
     )
 
-if not os.path.isdir(DIR):
-    sys.stdout.write(f"Creating {DIR}/...")
+if not os.path.isdir(args.target):
+    sys.stdout.write(f"Creating {args.target}/...")
     sys.stdout.flush()
 
-    os.mkdir(DIR)
+    os.mkdir(args.target)
     print("Done")
 
-print(f"Installing Pyodide {VERSION}:")
+print(f"Installing Pyodide {args.version}:")
 
 for file in FILES:
-    url = URL.format(file=file, CDN=CDN, VERSION=VERSION)
-    file = os.path.join(DIR, file)
+    url = URL.format(file=file, CDN=CDN, VERSION=args.version)
+    file = os.path.join(args.target, file)
 
     sys.stdout.write(f">>> {url}...")
     sys.stdout.flush()
 
     r = requests.get(url, stream=True)
+    assert r.status_code == 200, f"Error retrieving {url}"
+
     with open(file, "wb") as f:
         for chunk in r.iter_content(2 * 1024):
             f.write(chunk)
 
     print("Done")
 
-print(f"Done installing Pyodide {VERSION}")
+print(f"Done installing Pyodide {args.version}")
 
 # Patch pyodide.js to only use "/pyodide/"
-file = os.path.join(DIR, "pyodide.js")
+file = os.path.join(args.target, "pyodide.js")
 sys.stdout.write(f"Patching {file}...")
 sys.stdout.flush()
 
@@ -66,12 +76,12 @@ with open(file, "w") as f:
 print("Done")
 
 # Write a minimal packages.json with micropip, setuptools and distlibs pre-installed.
-file = os.path.join(DIR, "packages.json")
+file = os.path.join(args.target, "packages.json")
 sys.stdout.write(f"Rewriting {file}...")
 sys.stdout.flush()
 
 packages = requests.get(
-    URL.format(file="packages.json", CDN=CDN, VERSION=VERSION)
+    URL.format(file="packages.json", CDN=CDN, VERSION=args.version)
 ).json()
 
 for k in list(packages["packages"].keys()):


### PR DESCRIPTION
This pull request improves Flare for better integrate with Pyodide 0.18.0 and dev:

- get-pyodide.py
   - was updated to work with Pyodide 0.18.0 and Pyodide dev
   - now accepts for command-line parameters for further packages and parametrization
- The prelude-Parameter for the Flare initialization script became obsolete
- The packages array allows to specifiy further packages