### PR TITLE
fixed format in tree widget

### DIFF
--- a/flare/forms/widgets/tree.py
+++ b/flare/forms/widgets/tree.py
@@ -303,7 +303,7 @@ class TreeItemWidget(html5.Li):
 
         # In case there is no bone configured for visualization, use a format-string
         if not hasDescr:
-            format = "value['name']"  # default fallback
+            format = "name"  # default fallback
 
             if self.module in conf["modules"].keys():
                 moduleInfo = conf["modules"][self.module]


### PR DESCRIPTION
The fallback format was in obsolete style and would return None...