### PR TITLE
Update packages.json for user-specified packages

### DIFF
--- a/tools/get-pyodide.py
+++ b/tools/get-pyodide.py
@@ -48,12 +48,12 @@ if is_nano := args.version.endswith("-nano"):
     PACKAGES = []
 
 # Allow to install additional Pyodide pre-built packages by command-line arguments
-packages = PACKAGES + (args.packages or [])
+PACKAGES += (args.packages or [])
 
-if is_nano and packages:
+if is_nano and PACKAGES:
     raise EnvironmentError("Pyodide-nano does not support additionaly packages currently!")
 
-for package in packages:
+for package in PACKAGES:
     FILES.extend(
         [
             f"{package}.data",


### PR DESCRIPTION
Line 146 of `get-pyodide.py` overwrites the user-specified `packages` variable and line 149 only keeps the default packages, ignoring the user-specified ones. The result is that user-specified packages are fetched, but are not importable.

Extend the default global `PACKAGES` variable with the user-specified packages and use this variable when referencing packages to fetch and include.