### PR TITLE
Fix maxLength attribute, as maxlength is invalid

### DIFF
--- a/flare/html5/core.py
+++ b/flare/html5/core.py
@@ -1410,10 +1410,10 @@ class _attrFor(object):
 
 class _attrInputs(_attrRequired):
     def _getMaxlength(self):
-        return self.element.maxlength
+        return self.element.maxLength
 
     def _setMaxlength(self, val):
-        self.element.maxlength = val
+        self.element.maxLength = val
 
     def _getPlaceholder(self):
         return self.element.placeholder


### PR DESCRIPTION
This fix was reported by https://github.com/viur-framework/viur-html5/pull/26 and fixes the same attribute calls in Flare, too.